### PR TITLE
Create passthrough stream to get FileType

### DIFF
--- a/src/server/upload/controller.js
+++ b/src/server/upload/controller.js
@@ -58,9 +58,8 @@ const uploadController = {
         if (files[f]) {
           const file = files[f]
           if (file.hapi?.filename) {
-            request.logger.info(
-              `Uploading ${JSON.stringify(file.hapi.filename)}`
-            )
+            request.logger.info(`Uploading ${file.hapi.filename}`)
+
             const fileKey = `${id}/${file.hapi.filename}`
 
             // TODO: check result of upload and redirect on error
@@ -78,7 +77,7 @@ const uploadController = {
             uploadDetails.fields[f] = {
               fileName: file.hapi?.filename,
               contentType: file.hapi?.headers['content-type'] ?? '',
-              actualContentType: uploadResult.mimeType
+              actualContentType: uploadResult.fileTypeResult?.mime
             }
           } else {
             // save non-file fields


### PR DESCRIPTION
- Uploads the image:
<img width="1147" alt="Screenshot 2024-04-04 at 14 39 54" src="https://github.com/DEFRA/cdp-uploader/assets/2305016/956ea249-51b5-45c4-80a6-03228dda1f37">


- Provides the actual `"actualContentType": "image/jpeg"`
```
{
    "successRedirect": "http://localhost:3000/animals/add/status-poller",
    "failureRedirect": "http://localhost:3000/animals/add/status-poller",
    "scanResultCallback": "http://localhost:3000",
    "destinationBucket": "cdp-local-uploads",
    "acceptedMimeTypes": [
        ".pdf",
        ".csv",
        ".png",
        "image/jpeg"
    ],
    "maxFileSize": 100,
    "destinationPath": "",
    "initiated": "2024-04-04T13:39:02.062Z",
    "fields": {
        "file": {
            "fileName": "yak.jpg",
            "contentType": "image/jpeg",
            "actualContentType": "image/jpeg"
        }
    },
    "quarantined": "2024-04-04T13:39:10.842Z",
    "scanResult": {
        "safe": true,
        "fileUrl": "cdp-local-uploads/ab377521-dd3d-45a2-9d3f-80d5823da8a5/yak.jpg"
    },
    "scanned": "2024-04-04T13:39:37.387Z",
    "delivered": "2024-04-04T13:39:37.399Z"
}
```