### PR TITLE
Add hasError and errrMessage to files

### DIFF
--- a/src/server/common/helpers/scan-result-response.js
+++ b/src/server/common/helpers/scan-result-response.js
@@ -23,7 +23,11 @@ function toFilesResponse(uploadId, files) {
     contentLength: file.contentLength,
     filename: file.filename,
     s3Bucket: file.s3Bucket,
-    s3Key: file.s3Key
+    s3Key: file.s3Key,
+    hasError: file.hasError,
+    ...(file?.errorMessage && {
+      errorMessage: file.errorMessage
+    })
   }))
 }
 

--- a/src/server/common/helpers/scan-result-response.test.js
+++ b/src/server/common/helpers/scan-result-response.test.js
@@ -36,6 +36,7 @@ describe('#toScanResultResponse', () => {
           fileId: '7507f65a-acb5-41f2-815f-719fbbd47ee5',
           fileStatus: 'complete',
           filename: 'shoot.jpg',
+          hasError: false,
           s3Bucket: 'cdp-example-node-frontend',
           s3Key:
             '/plants/f5aa7920-6c3d-4090-a0c5-a0002df2c285/7507f65a-acb5-41f2-815f-719fbbd47ee5',
@@ -78,9 +79,11 @@ describe('#toScanResultResponse', () => {
         {
           contentLength: 10503,
           contentType: 'image/jpeg',
+          errorMessage: 'The selected file contains a virus',
           fileId: 'f45d0dd4-dd3f-4235-9c45-da2edd5c89fd',
           fileStatus: 'complete',
           filename: 'succulant.jpeg',
+          hasError: true,
           uploadId: '619cdb5b-31b2-4747-9d7b-2bd447a1f7d7'
         }
       ],

--- a/src/server/common/helpers/update-fields-response.js
+++ b/src/server/common/helpers/update-fields-response.js
@@ -4,10 +4,10 @@
  * - Add data to formData fields data matched by fileId
  * - Pass items without fileId through, as is
  * @param formData
- * @param fieldUpdates
+ * @param files
  * @returns {{}|*}
  */
-function updateFieldsResponse(formData, fieldUpdates) {
+function updateFieldsResponse(formData, files) {
   const updateFields = (fieldUpdate) => ({
     s3Key: fieldUpdate.s3Key,
     s3Bucket: fieldUpdate.s3Bucket,
@@ -27,14 +27,14 @@ function updateFieldsResponse(formData, fieldUpdates) {
 
       const updatedFieldValues = fieldValues
         .map((fieldValue) => {
-          const matchedFieldUpdate = fieldUpdates.find(
-            (fieldUpdate) => fieldUpdate.fileId === fieldValue.fileId
+          const matchedFileUpdate = files.find(
+            (fileUpdate) => fileUpdate.fileId === fieldValue.fileId
           )
 
-          if (matchedFieldUpdate) {
+          if (matchedFileUpdate) {
             return {
               ...fieldValue,
-              ...updateFields(matchedFieldUpdate)
+              ...updateFields(matchedFileUpdate)
             }
           }
 


### PR DESCRIPTION
Provides:

```
{
  "destinationBucket": "cdp-example-node-frontend",
  "destinationPath": "/plants",
  "fields": {
    "button": "upload",
    "file": {
      "actualContentType": "image/jpeg",
      "contentLength": 10503,
      "contentType": "image/jpeg",
      "errorMessage": "The selected file contains a virus",
      "fileStatus": "complete",
      "filename": "succulant.jpeg",
      "hasError": true
    }
  },
  "files": [
    {
      "contentLength": 10503,
      "contentType": "image/jpeg",
      "errorMessage": "The selected file contains a virus",
      "fileId": "f45d0dd4-dd3f-4235-9c45-da2edd5c89fd",
      "fileStatus": "complete",
      "filename": "succulant.jpeg",
      "hasError": true,
      "uploadId": "619cdb5b-31b2-4747-9d7b-2bd447a1f7d7"
    }
  ],
  "metadata": {
    "plantId": "94f8a562-630c-4569-b3a3-2503408c4129"
  },
  "numberOfRejectedFiles": 1,
  "redirect": "http://redirect.com/plants/add/status-poller?uploadId=619cdb5b-31b2-4747-9d7b-2bd447a1f7d7",
  "uploadStatus": "ready"
}
```