### PR TITLE
Add service to buckets allowlist

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -3,6 +3,20 @@ import path from 'node:path'
 
 const oneWeekMillis = 7 * 24 * 60 * 60 * 1000
 
+convict.addFormat({
+  name: 'bucket-array',
+  validate: function (values) {
+    const isProduction = process.env.NODE_ENV === 'production'
+
+    if (isProduction && values.length === 0) {
+      throw new Error('CONSUMER_BUCKETS environment variable must be set')
+    }
+  },
+  coerce: function (value) {
+    return value.split(',')
+  }
+})
+
 const config = convict({
   env: {
     doc: 'The application environment.',
@@ -182,6 +196,12 @@ const config = convict({
     format: Number,
     default: 200 * 1024 * 1024,
     env: 'MAX_FILE_SIZE'
+  },
+  bucketsAllowlist: {
+    doc: 'Allowlist buckets that can be used in environments',
+    format: 'bucket-array',
+    default: [],
+    env: 'CONSUMER_BUCKETS'
   }
 })
 

--- a/src/server/initiate/controller.js
+++ b/src/server/initiate/controller.js
@@ -23,9 +23,9 @@ const initiateController = {
   },
   handler: async (request, h) => {
     const uploadId = crypto.randomUUID()
-    const initateRequest = request.payload
+    const initiateRequest = request.payload
 
-    initateRequest.redirect = withQueryParams(initateRequest.redirect, {
+    initiateRequest.redirect = withQueryParams(initiateRequest.redirect, {
       uploadId
     })
 
@@ -35,7 +35,7 @@ const initiateController = {
       initiated: new Date().toISOString(),
       form: {},
       fileIds: [],
-      request: initateRequest
+      request: initiateRequest
     }
 
     await request.redis.storeUploadDetails(uploadId, uploadDetails)

--- a/src/server/initiate/helpers/initiate-validation.js
+++ b/src/server/initiate/helpers/initiate-validation.js
@@ -2,13 +2,20 @@ import Joi from 'joi'
 import { config } from '~/src/config'
 
 const isProduction = !config.get('isProduction')
+const bucketsAllowlist = config.get('bucketsAllowlist')
 
 const initiateValidation = Joi.object({
   redirect: Joi.string()
     .uri({ allowRelative: true, ...(isProduction && { relativeOnly: true }) })
     .required(),
   callback: Joi.string().uri().optional(),
-  s3Bucket: Joi.string().required(),
+  s3Bucket: Joi.string()
+    .required()
+    .valid(...bucketsAllowlist)
+    .messages({
+      'any.only':
+        'No permission to write to bucket - Please contact CDP Portal Team'
+    }),
   s3Path: Joi.string().optional(),
   mimeTypes: Joi.array().items(Joi.string()).optional(),
   maxFileSize: Joi.number().integer().positive().optional(),


### PR DESCRIPTION
Intention:
- Don't restrict bucket access locally as this will get in the way of integrating with cdp-uploader
- In Environments config should be specified as:
```
CONSUMER_BUCKETS=cdp-infra-dev-cdp-example-node-frontend-f5a9fee866ed,my-bucket,my-bucket2
```
