### PR TITLE
Restrict redirects to relative uris in environments

### DIFF
--- a/src/server/initiate/helpers/initiate-validation.js
+++ b/src/server/initiate/helpers/initiate-validation.js
@@ -1,7 +1,12 @@
 import Joi from 'joi'
+import { config } from '~/src/config'
+
+const isProduction = !config.get('isProduction')
 
 const initiateValidation = Joi.object({
-  redirect: Joi.string().uri().required(),
+  redirect: Joi.string()
+    .uri({ allowRelative: true, ...(isProduction && { relativeOnly: true }) })
+    .required(),
   callback: Joi.string().uri().optional(),
   s3Bucket: Joi.string().required(),
   s3Path: Joi.string().optional(),


### PR DESCRIPTION
We weren't allowing relative Uris at all so have enabled for local dev & restricted to just relative for node production