### PR TITLE
Allow overriding mock-clamav queue URL via SQS_MOCK_CLAMAV env

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -235,6 +235,32 @@ export const config = convict({
       env: 'SQS_DOWNLOAD_REQUESTS_BATCH_SIZE'
     }
   },
+  sqsMockClamav: {
+    queueUrl: {
+      doc: 'Queue used by the mock virus scanner test harness',
+      format: String,
+      default: 'mock-clamav',
+      env: 'SQS_MOCK_CLAMAV'
+    },
+    waitTimeSeconds: {
+      doc: 'The duration for which the call will wait for a message to arrive in the queue before returning',
+      format: Number,
+      default: 3,
+      env: 'SQS_MOCK_CLAMAV_WAIT_TIME_SECONDS'
+    },
+    pollingWaitTimeMs: {
+      doc: 'The duration to wait before re-polling the queue',
+      format: Number,
+      default: 100,
+      env: 'SQS_MOCK_CLAMAV_POLLING_WAIT_TIME_MS'
+    },
+    batchSize: {
+      doc: 'The number of messages to request from SQS when polling (max 10)',
+      format: Number,
+      default: 1,
+      env: 'SQS_MOCK_CLAMAV_BATCH_SIZE'
+    }
+  },
   mockVirusRegex: {
     doc: 'Filename pattern used by test harness to simulate viruses',
     format: String,

--- a/src/server/common/helpers/sqs/sqs-listener.js
+++ b/src/server/common/helpers/sqs/sqs-listener.js
@@ -98,13 +98,7 @@ const downloadRequestsListener = {
 const mockClamavListener = {
   plugin: sqsListener,
   options: {
-    config: {
-      queueUrl: 'mock-clamav',
-      visibilityTimeout: 2,
-      waitTimeSeconds: 3,
-      pollingWaitTimeMs: 100,
-      batchSize: 1
-    },
+    config: config.get('sqsMockClamav'),
     messageHandler: async (message, queueUrl, server) =>
       await handleMockVirusScanner(message, queueUrl, server)
   }


### PR DESCRIPTION
## Summary

The test-harness `mockClamavListener` hardcodes its queue URL as the bare string `'mock-clamav'`. LocalStack accepts bare names, but stricter SQS implementations (e.g. [Floci](https://github.com/floci-io/floci)) parse `QueueUrl` as a URL and return `QueueDoesNotExist` for anything that isn't a full URL or path-form `/<account>/<name>`.

This change adds an `sqsMockClamav` config block that mirrors the pattern of the other three SQS listeners in this file (`sqsScanResults`, `sqsScanResultsCallback`, `sqsDownloadRequests`), exposing `SQS_MOCK_CLAMAV` plus the usual timing env vars. The default stays `'mock-clamav'`, so LocalStack continues to work unchanged.

The previously inline (and unused) `visibilityTimeout: 2` property is dropped — the `sqs-listener` plugin does not consume it.

## Why this matters

Downstream teams integrating cdp-uploader with alternative local SQS backends currently cannot override the test-harness listener's queue URL because it is not routed through `config.get(...)`. With this change, a consumer can point mock-clamav at a different backend with a single env var:

```
SQS_MOCK_CLAMAV=http://floci:4566/000000000000/mock-clamav
```

No existing behaviour changes when the env var is unset.

## Changes

- `src/config/index.js` — add `sqsMockClamav` convict block (same shape as the other three SQS blocks)
- `src/server/common/helpers/sqs/sqs-listener.js` — replace the inline `config: { queueUrl: 'mock-clamav', ... }` literal with `config: config.get('sqsMockClamav')`

## Verified locally

- `npm test` (78 tests)
- `npm run test:e2e` against LocalStack (22 tests)
- `npm run lint` (eslint, stylelint, tsc)
- `npm run format:check`
- Config loading with and without `SQS_MOCK_CLAMAV` set