### PR TITLE
CORE-3636: Return numberOfRectedFiles on ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,11 +401,11 @@ If multiple download URLs were provided:
 
 
 | Parameter Name        | Description                                                                                                                                                  |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| --------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | uploaderStatus        | Have all scans completed, can be `initiated`, `pending` or `ready`                                                                                           |
 | metadata              | Extra data and identified set by the requesting service in the /initialize call. Returned exactly as they were presented                                     |
 | form                  | An object representing each field in the multipart request. Text fields are preserved exactly as they were sent, file fields contain details about the file. |
-| numberOfRejectedFiles | Total number of files that have been rejected by the uploader                                                                                                |
+| numberOfRejectedFiles | Total number of files rejected by the uploader. Present when `uploadStatus` is `ready`; absent for `initiated` and `pending`.                                |
 | debug.request         | When set to true, the initiate request payload received by cdp-uploader                                                                                      |
 
 ### File field in form
@@ -488,7 +488,7 @@ The request is sent with `Content-Type: application/json`.
 | `uploadStatus`        | `string` | Always `"ready"` when the callback fires. All scans have completed.                                                    |
 | `metadata`            | `object` | The metadata object supplied in the `/initiate` request, returned exactly as provided. `undefined` if none was set.     |
 | `form`                | `object` | An object representing each field in the multipart request (or download). See [File fields in callback](#file-fields-in-callback) below. |
-| `numberOfRejectedFiles` | `number` | Count of files that were rejected (virus, empty, too large, wrong mime type, download failure, or server error).      |
+| `numberOfRejectedFiles` | `number` | Count of files rejected (virus, empty, too large, wrong mime type, download failure, or server error). Always present in callbacks. |
 
 ### File fields in callback
 

--- a/src/server/common/helpers/scan-result-response.js
+++ b/src/server/common/helpers/scan-result-response.js
@@ -1,4 +1,5 @@
 import { updateFormsResponse } from '~/src/server/common/helpers/update-forms-response.js'
+import { uploadStatus } from '~/src/server/common/helpers/upload-status.js'
 
 function toScanResultResponse(uploadId, uploadDetails, files, debug) {
   // preserve ordering of mandatory & optional keys between status changes
@@ -12,7 +13,10 @@ function toScanResultResponse(uploadId, uploadDetails, files, debug) {
     uploadStatus: uploadDetails.uploadStatus,
     metadata: uploadDetails.request.metadata,
     form: updateFormsResponse(uploadDetails.form, files),
-    numberOfRejectedFiles: uploadDetails.numberOfRejectedFiles
+    numberOfRejectedFiles:
+      uploadDetails.uploadStatus === uploadStatus.ready.description
+        ? (uploadDetails.numberOfRejectedFiles ?? 0)
+        : uploadDetails.numberOfRejectedFiles
   }
 }
 

--- a/src/server/common/helpers/scan-result-response.test.js
+++ b/src/server/common/helpers/scan-result-response.test.js
@@ -1,6 +1,8 @@
 import { toScanResultResponse } from '~/src/server/common/helpers/scan-result-response.js'
 import { uploadDetailsSuccessFixture } from '~/src/__fixtures__/upload-details-success.js'
 import { uploadDetailsRejectedVirusFixture } from '~/src/__fixtures__/upload-details-rejected-virus.js'
+import { uploadDetailsReadyFixture } from '~/src/__fixtures__/upload-details-ready.js'
+import { uploadDetailsPendingFixture } from '~/src/__fixtures__/upload-details-pending.js'
 import { fileDetailsRejectedVirusFixture } from '~/src/__fixtures__/file-details-rejected-virus.js'
 import { fileDetailsCompleteFixture } from '~/src/__fixtures__/file-details-complete.js'
 
@@ -151,6 +153,58 @@ describe('#toScanResultResponse', () => {
       },
       numberOfRejectedFiles: 1,
       uploadStatus: 'ready'
+    })
+  })
+
+  test('Should default numberOfRejectedFiles to 0 when uploadStatus is ready and count is missing', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- omit field for test
+    const { numberOfRejectedFiles, ...uploadDetails } =
+      uploadDetailsReadyFixture
+
+    expect(
+      toScanResultResponse(uploadDetails.uploadId, uploadDetails, [], false)
+    ).toEqual({
+      uploadStatus: 'ready',
+      metadata: {
+        plantId: '94f8a562-630c-4569-b3a3-2503408c4129'
+      },
+      form: {
+        button: 'upload',
+        file: {
+          fileId: '7507f65a-acb5-41f2-815f-719fbbd47ee5',
+          filename: 'shoot.jpg',
+          contentType: 'image/jpeg'
+        }
+      },
+      numberOfRejectedFiles: 0
+    })
+  })
+
+  test('Should omit numberOfRejectedFiles when uploadStatus is pending and count is missing', () => {
+    const serialised = JSON.parse(
+      JSON.stringify(
+        toScanResultResponse(
+          uploadDetailsPendingFixture.uploadId,
+          uploadDetailsPendingFixture,
+          [],
+          false
+        )
+      )
+    )
+
+    expect(serialised).toEqual({
+      uploadStatus: 'pending',
+      metadata: {
+        plantId: 'c316e7ae-3c58-49f8-96a9-cb9058c9ea31'
+      },
+      form: {
+        button: 'upload',
+        file: {
+          fileId: 'd3e1ccfa-3f58-435d-af9a-dad7b20ab11b',
+          filename: 'shoot.jpg',
+          contentType: 'image/jpeg'
+        }
+      }
     })
   })
 })

--- a/src/server/status/controller.js
+++ b/src/server/status/controller.js
@@ -64,7 +64,14 @@ const statusController = {
               }
             }),
 
-          numberOfRejectedFiles: Joi.number().integer().example(0),
+          numberOfRejectedFiles: Joi.number()
+            .integer()
+            .example(0)
+            .when('uploadStatus', {
+              is: 'ready',
+              then: Joi.required(),
+              otherwise: Joi.optional()
+            }),
 
           debug: Joi.object()
             .unknown(true)

--- a/src/server/upload-and-scan/controller.js
+++ b/src/server/upload-and-scan/controller.js
@@ -158,6 +158,7 @@ const uploadController = {
       // If no files are submitted jump straight to 'ready'.
       if (fileStatuses.length === 0) {
         uploadDetails.uploadStatus = uploadStatus.ready.description
+        uploadDetails.numberOfRejectedFiles = 0
       }
 
       await request.redis.storeUploadDetails(uploadId, uploadDetails)


### PR DESCRIPTION
return `numberOfRejectedFiles` always when it's ready status to avoid surprises on the client side. The field is mandatory for ready status.