### PR TITLE
CORE-3555: Fix: report ClamAV scan-limit exceedance as upload failure, not virus

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ The `errorMessage` field is a text description of why the file was rejected.
 | File is empty                                                                               | `FILE_EMPTY`           | —                             | `The selected file is empty`                            |
 | File size exceeds max size (either set in the /init call or the uploaders max default 100M) | `FILE_TOO_LARGE`       | `{ "maxFileSize": <bytes> }`  | `The selected file must be smaller than $MAXSIZE`       |
 | File doesn't match the mime types set in the init call                                      | `FILE_INVALID_TYPE`    | `{ "mimeTypes": [...] }`      | `The selected file must be a $MIMETYPES`                |
-| Any server side error in CDP-Uploader                                                       | `FILE_UPLOAD_FAILED`   | —                             | `The selected file could not be uploaded – try again`   |
+| Server-side upload/scan failure (including virus scan limit exceeded)                       | `FILE_UPLOAD_FAILED`   | —                             | `The selected file could not be uploaded – try again`   |
 | Failed download                                                                             | `FILE_DOWNLOAD_FAILED` | —                             | `The selected file could not be downloaded`             |
 
 
@@ -473,6 +473,23 @@ const messages = {
 const text = messages[locale][file.errorCode](file.errorParams ?? {})
 ```
 
+#### Virus scan limit exceeded
+
+When ClamAV's `AlertExceedsMax` option is enabled, files that exceed a scan limit (size, recursion depth, scan time,
+etc.) are reported with a `FOUND` status and a virus name prefixed `Heuristics.Limits.Exceeded`. This does **not** mean
+the file is infected, only that scanning could not complete within the configured limits.
+
+`cdp-uploader` detects this prefix and returns the existing `FILE_UPLOAD_FAILED` error instead of `FILE_VIRUS`, so
+tenants that already handle known error codes do not need a new code.
+
+References:
+
+- [clamd.conf man page - `AlertExceedsMax`](https://github.com/Cisco-Talos/clamav/blob/main/docs/man/clamd.conf.5.in)
+- [clamdscan man page - tooling should handle this case](https://manpages.opensuse.org/Tumbleweed/clamav/clamdscan.1.en.html)
+- [clamav-users mailing list - known
+  `Heuristics.Limits.Exceeded.*` suffixes](https://www.mail-archive.com/clamav-users@lists.clamav.net/msg52438.html)
+- [ClamAV 0.103.4/0.104.1 release notes - naming convention details](https://lists.clamav.net/pipermail/clamav-announce/2021/000058.html)
+
 ## Callback
 
 If a `callback` URL was provided in the `/initiate` request, cdp-uploader will `POST` a JSON payload to that URL once
@@ -488,7 +505,7 @@ The request is sent with `Content-Type: application/json`.
 | `uploadStatus`        | `string` | Always `"ready"` when the callback fires. All scans have completed.                                                    |
 | `metadata`            | `object` | The metadata object supplied in the `/initiate` request, returned exactly as provided. `undefined` if none was set.     |
 | `form`                | `object` | An object representing each field in the multipart request (or download). See [File fields in callback](#file-fields-in-callback) below. |
-| `numberOfRejectedFiles` | `number` | Count of files rejected (virus, empty, too large, wrong mime type, download failure, or server error). Always present in callbacks. |
+| `numberOfRejectedFiles` | `number` | Count of files rejected (virus, scan failure, empty, too large, wrong mime type, download failure, or server error). Always present in callbacks. |
 
 ### File fields in callback
 

--- a/src/__fixtures__/file-details-rejected-scan-failed.js
+++ b/src/__fixtures__/file-details-rejected-scan-failed.js
@@ -1,0 +1,17 @@
+const fileDetailsRejectedScanFailedFixture = {
+  uploadId: '619cdb5b-31b2-4747-9d7b-2bd447a1f7d7',
+  fileId: 'f45d0dd4-dd3f-4235-9c45-da2edd5c89fd',
+  fileStatus: 'rejected',
+  pending: '2024-04-29T09:42:30.708Z',
+  detectedContentType: 'image/jpeg',
+  contentLength: 10503,
+  checksumSha256: 'bng5jOVC6TxEgwTUlX4DikFtDEYEc8vQTsOP0ZAv21c=',
+  contentType: 'image/jpeg',
+  filename: 'succulant.jpeg',
+  scanned: '2024-04-29T09:43:31.373Z',
+  hasError: true,
+  errorCode: 'FILE_UPLOAD_FAILED',
+  errorMessage: 'The selected file could not be uploaded – try again'
+}
+
+export { fileDetailsRejectedScanFailedFixture }

--- a/src/server/common/helpers/scan-result-response.test.js
+++ b/src/server/common/helpers/scan-result-response.test.js
@@ -4,6 +4,7 @@ import { uploadDetailsRejectedVirusFixture } from '~/src/__fixtures__/upload-det
 import { uploadDetailsReadyFixture } from '~/src/__fixtures__/upload-details-ready.js'
 import { uploadDetailsPendingFixture } from '~/src/__fixtures__/upload-details-pending.js'
 import { fileDetailsRejectedVirusFixture } from '~/src/__fixtures__/file-details-rejected-virus.js'
+import { fileDetailsRejectedScanFailedFixture } from '~/src/__fixtures__/file-details-rejected-scan-failed.js'
 import { fileDetailsCompleteFixture } from '~/src/__fixtures__/file-details-complete.js'
 
 describe('#toScanResultResponse', () => {
@@ -142,6 +143,38 @@ describe('#toScanResultResponse', () => {
           contentType: 'image/jpeg',
           errorMessage: 'The selected file contains a virus',
           errorCode: 'FILE_VIRUS',
+          fileStatus: 'rejected',
+          filename: 'succulant.jpeg',
+          checksumSha256: 'bng5jOVC6TxEgwTUlX4DikFtDEYEc8vQTsOP0ZAv21c=',
+          hasError: true
+        }
+      },
+      metadata: {
+        plantId: '94f8a562-630c-4569-b3a3-2503408c4129'
+      },
+      numberOfRejectedFiles: 1,
+      uploadStatus: 'ready'
+    })
+  })
+
+  test('Should provide expected response for rejected scan-limit-exceeded upload', () => {
+    expect(
+      toScanResultResponse(
+        uploadDetailsRejectedVirusFixture.uploadId,
+        uploadDetailsRejectedVirusFixture,
+        [fileDetailsRejectedScanFailedFixture],
+        false
+      )
+    ).toEqual({
+      form: {
+        button: 'upload',
+        file: {
+          fileId: 'f45d0dd4-dd3f-4235-9c45-da2edd5c89fd',
+          detectedContentType: 'image/jpeg',
+          contentLength: 10503,
+          contentType: 'image/jpeg',
+          errorMessage: 'The selected file could not be uploaded – try again',
+          errorCode: 'FILE_UPLOAD_FAILED',
           fileStatus: 'rejected',
           filename: 'succulant.jpeg',
           checksumSha256: 'bng5jOVC6TxEgwTUlX4DikFtDEYEc8vQTsOP0ZAv21c=',

--- a/src/server/scan/listener/handle-scan-result.js
+++ b/src/server/scan/listener/handle-scan-result.js
@@ -59,21 +59,34 @@ async function handleScanResult(message, scanResultQueueUrl, server) {
 
   if (fileDetails.fileStatus === fileStatus.pending) {
     const virusStatus = payload.status?.toLowerCase()
+    const scanLimitExceeded = (payload.message ?? '').includes(
+      'Heuristics.Limits.Exceeded'
+    )
 
     fileDetails.scanned = new Date().toISOString()
 
     if (virusStatus === scanStatus.infected) {
       fileDetails.hasError = true
-      fileDetails.errorMessage = fileErrors.virus.message
-      fileDetails.errorCode = fileErrors.virus.code
+      fileDetails.errorMessage = scanLimitExceeded
+        ? fileErrors.uploadFailed.message
+        : fileErrors.virus.message
+      fileDetails.errorCode = scanLimitExceeded
+        ? fileErrors.uploadFailed.code
+        : fileErrors.virus.code
       fileDetails.fileStatus = fileStatus.rejected
 
       await server.redis.storeFileDetails(fileId, fileDetails)
       await deleteSqsMessage(server.sqs, scanResultQueueUrl, receiptHandle)
 
-      await server.metrics().counter('file-infected')
+      await server
+        .metrics()
+        .counter(
+          scanLimitExceeded ? 'file-scan-limit-exceeded' : 'file-infected'
+        )
 
-      fileLogger.info(`Virus found. Message: ${payload.message}`)
+      fileLogger.info(
+        `${scanLimitExceeded ? 'Scan limit exceeded' : 'Virus found'}. Message: ${payload.message}`
+      )
     }
 
     if (virusStatus === scanStatus.clean) {

--- a/src/server/scan/listener/handle-scan-result.test.js
+++ b/src/server/scan/listener/handle-scan-result.test.js
@@ -15,14 +15,24 @@ jest.mock('~/src/server/scan/listener/helpers/process-scan-complete.js')
 jest.mock('~/src/server/common/helpers/s3/move-s3-object.js')
 
 class Metrics {
-  timer = jest.fn()
   counter = jest.fn()
   byteSize = jest.fn()
   millis = jest.fn()
 }
 
+const virusCheckMessageScanLimitExceededFixture = {
+  ...virusCheckMessageInfectedFixture,
+  Body: JSON.stringify({
+    ...JSON.parse(virusCheckMessageInfectedFixture.Body),
+    message: `cleanfile.txt: Heuristics.Limits.Exceeded.MaxScanTime FOUND
+----------- SCAN SUMMARY -----------
+Infected files: 1`
+  })
+}
+
 describe('#handleScanResult', () => {
   const logger = createLogger()
+  const mockMetrics = new Metrics()
   const mockFindUploadDetails = jest.fn()
   const mockFindFileDetails = jest.fn()
   const mockFindUploadAndFiles = jest.fn()
@@ -35,7 +45,7 @@ describe('#handleScanResult', () => {
       findUploadAndFiles: mockFindUploadAndFiles,
       storeFileDetails: mockStoreFileDetails
     },
-    metrics: () => new Metrics(),
+    metrics: () => mockMetrics,
     logger
   }
   const mockLogger = {
@@ -49,7 +59,11 @@ describe('#handleScanResult', () => {
 
   beforeAll(() => {
     jest.useFakeTimers()
-    jest.setSystemTime(new Date('2024-04-29T14:10:00'))
+    jest.setSystemTime(new Date('2024-04-29T14:10:00.000Z'))
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
   })
 
   afterAll(() => {
@@ -192,6 +206,14 @@ describe('#handleScanResult', () => {
       )
     })
 
+    test('Should increment infected metric', () => {
+      const counterCalls = mockMetrics.counter.mock.calls.map(
+        ([metricName]) => metricName
+      )
+      expect(counterCalls).toContain('file-infected')
+      expect(counterCalls).not.toContain('file-scan-limit-exceeded')
+    })
+
     test('Should delete Sqs message', () => {
       expect(deleteSqsMessage).toHaveBeenCalledTimes(1)
       expect(deleteSqsMessage).toHaveBeenCalledWith(
@@ -199,6 +221,78 @@ describe('#handleScanResult', () => {
         'mock-virus-scan-queue-url',
         '123456-78910'
       )
+    })
+
+    test('Should call process scan complete with expected values', () => {
+      expect(processScanComplete).toHaveBeenCalledTimes(1)
+      expect(processScanComplete).toHaveBeenCalledWith(
+        'mock-id-34543',
+        'mock-key-87678',
+        mockServer
+      )
+    })
+
+    test('Should return "undefined"', () => {
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('When file scan exceeds ClamAV limits', () => {
+    let result
+
+    beforeEach(async () => {
+      // Copies needed due to mutations within the file being tested
+      const uploadDetailsPendingFixtureCopy = { ...uploadDetailsPendingFixture }
+      const fileDetailsPendingFixtureCopy = { ...fileDetailsPendingFixture }
+
+      mockFindUploadDetails.mockResolvedValue(uploadDetailsPendingFixtureCopy)
+      mockFindFileDetails.mockResolvedValue(fileDetailsPendingFixtureCopy)
+      mockFindUploadAndFiles.mockResolvedValue({
+        files: [fileDetailsPendingFixture],
+        uploadDetails: uploadDetailsPendingFixture
+      })
+
+      result = await handleScanResult(
+        virusCheckMessageScanLimitExceededFixture,
+        'mock-virus-scan-queue-url',
+        mockServer
+      )
+    })
+
+    test('Should mark file as upload failed and rejected', () => {
+      expect(mockStoreFileDetails).toHaveBeenCalledTimes(1)
+      expect(mockStoreFileDetails).toHaveBeenCalledWith('mock-key-87678', {
+        detectedContentType: 'image/webp',
+        contentLength: 25624,
+        contentType: 'image/jpeg',
+        errorMessage: 'The selected file could not be uploaded – try again',
+        errorCode: 'FILE_UPLOAD_FAILED',
+        fileId: 'd3e1ccfa-3f58-435d-af9a-dad7b20ab11b',
+        fileStatus: 'rejected',
+        filename: 'shoot.jpg',
+        hasError: true,
+        pending: '2024-04-29T13:41:47.466Z',
+        scanned: '2024-04-29T14:10:00.000Z',
+        uploadId: 'ba0a64c7-8b1c-4237-9256-b9c4a3c8fe68',
+        checksumSha256: 'bng5jOVC6TxEgwTUlX4DikFtDEYEc8vQTsOP0ZAv21c='
+      })
+    })
+
+    test('Should log expected scan limit exceeded info', () => {
+      expect(mockLogger.info).toHaveBeenCalledTimes(1)
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        `Scan limit exceeded. Message: cleanfile.txt: Heuristics.Limits.Exceeded.MaxScanTime FOUND
+----------- SCAN SUMMARY -----------
+Infected files: 1`
+      )
+    })
+
+    test('Should increment scan-limit-exceeded metric', () => {
+      const counterCalls = mockMetrics.counter.mock.calls.map(
+        ([metricName]) => metricName
+      )
+      expect(counterCalls).toContain('file-scan-limit-exceeded')
+      expect(counterCalls).not.toContain('file-infected')
     })
 
     test('Should call process scan complete with expected values', () => {


### PR DESCRIPTION
- Stop treating ClamAV scan-limit exceedances (Heuristics.Limits.Exceeded…) as viruses
- Map those results to existing FILE_UPLOAD_FAILED instead of FILE_VIRUS
- Keep genuine infections as FILE_VIRUS