### PR TITLE
CORE-000: Add fileExtensions and maxFileSizeFormatted to uploader errorParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,8 +443,8 @@ The `errorMessage` field is a text description of why the file was rejected.
 |---------------------------------------------------------------------------------------------|------------------------|-------------------------------|---------------------------------------------------------|
 | Virus detected                                                                              | `FILE_VIRUS`           | —                             | `The selected file contains a virus`                    |
 | File is empty                                                                               | `FILE_EMPTY`           | —                             | `The selected file is empty`                            |
-| File size exceeds max size (either set in the /init call or the uploaders max default 100M) | `FILE_TOO_LARGE`       | `{ "maxFileSize": <bytes> }`  | `The selected file must be smaller than $MAXSIZE`       |
-| File doesn't match the mime types set in the init call                                      | `FILE_INVALID_TYPE`    | `{ "mimeTypes": [...] }`      | `The selected file must be a $MIMETYPES`                |
+| File size exceeds max size (either set in the /init call or the uploaders max default 100M) | `FILE_TOO_LARGE`       | `{ "maxFileSize": <bytes>, "maxFileSizeFormatted": "<size>" }`  | `The selected file must be smaller than $MAXSIZE`       |
+| File doesn't match the mime types set in the init call                                      | `FILE_INVALID_TYPE`    | `{ "mimeTypes": [...], "fileExtensions": [...] }`      | `The selected file must be a $MIMETYPES`                |
 | Server-side upload/scan failure (including virus scan limit exceeded)                       | `FILE_UPLOAD_FAILED`   | —                             | `The selected file could not be uploaded – try again`   |
 | Failed download                                                                             | `FILE_DOWNLOAD_FAILED` | —                             | `The selected file could not be downloaded`             |
 
@@ -461,10 +461,10 @@ const messages = {
   en: {
     FILE_VIRUS: () => 'The selected file contains a virus',
     FILE_EMPTY: () => 'The selected file is empty',
-    FILE_TOO_LARGE: ({ maxFileSize }) =>
-      `The selected file must be smaller than ${maxFileSize} bytes`,
-    FILE_INVALID_TYPE: ({ mimeTypes }) =>
-      `The selected file must be a ${mimeTypes.join(', ')}`,
+    FILE_TOO_LARGE: ({ maxFileSize, maxFileSizeFormatted }) =>
+      `The selected file must be smaller than ${maxFileSizeFormatted ?? `${maxFileSize} bytes`}`,
+    FILE_INVALID_TYPE: ({ mimeTypes, fileExtensions }) =>
+      `The selected file must be a ${(fileExtensions ?? mimeTypes ?? []).join(', ')}`,
     FILE_UPLOAD_FAILED: () => 'The selected file could not be uploaded – try again',
     FILE_DOWNLOAD_FAILED: () => 'The selected file could not be downloaded'
   }
@@ -524,7 +524,7 @@ Text form fields are preserved as-is. File fields are objects with the following
 | `s3Key`               | `string`           | yes      | S3 object key (includes `s3Path` prefix if one was set in `/initiate`). Only set when `fileStatus` is `"complete"`.                                              |
 | `hasError`            | `boolean`          | yes      | `true` when the file has been rejected. `undefined` otherwise.                                                                                                   |
 | `errorCode`           | `string`           | yes      | Stable identifier for the rejection reason. Only present when `hasError` is `true`.                                                                              |
-| `errorParams`         | `object`           | yes      | Optional parameters for the error code (for example `{ "maxFileSize": 10000000 }`).                                                                              |
+| `errorParams`         | `object`           | yes      | Optional parameters for the error code (for example `{ "maxFileSize": 10000000, "maxFileSizeFormatted": "10 MB" }`).                                                                              |
 | `errorMessage`        | `string`           | yes      | Human-readable reason for rejection, suitable for displaying to end users (follows [GDS File Upload guidelines](https://design-system.service.gov.uk/components/file-upload/)). Only present when `hasError` is `true`. |
 | `downloadUrl`         | `string`           | yes      | The original download URL. Only present for uploads initiated via `downloadUrls`.                                                                                |
 

--- a/src/server/upload-and-scan/helpers/handle-file.js
+++ b/src/server/upload-and-scan/helpers/handle-file.js
@@ -102,17 +102,20 @@ function rejectZeroLengthFile(file) {
 
 function rejectTooBigFile(file, maxFileSize) {
   // Reject file if it's too big
+  const maxFileSizeFormatted = filesize(maxFileSize, { standard: 'si' })
+
   return file.contentLength > maxFileSize
     ? {
         fileStatus: fileStatus.rejected,
         hasError: true,
         errorMessage: fileErrors.tooBig.message.replace(
           '$MAXSIZE',
-          filesize(maxFileSize, { standard: 'si' })
+          maxFileSizeFormatted
         ),
         errorCode: fileErrors.tooBig.code,
         errorParams: {
-          maxFileSize
+          maxFileSize,
+          maxFileSizeFormatted
         }
       }
     : {}
@@ -124,33 +127,39 @@ function rejectWrongMimeType(contentType, mimeTypes) {
   const mimeTypeMismatch =
     mimeTypes && !mimeTypes.some((m) => m === contentType)
 
-  const createMessage = () => {
-    const extensions = mimeTypes
-      .map((mimeType) => mime.extension(mimeType))
-      .filter(Boolean)
-      .map((mimeType) => mimeType.toUpperCase())
-    const uniqueExtensions = Array.from(new Set(extensions))
-
-    const last = uniqueExtensions.pop()
-    return uniqueExtensions.length
-      ? uniqueExtensions.join(', ') + ' or ' + last
-      : last
+  if (!mimeTypeMismatch) {
+    return {}
   }
 
-  return mimeTypeMismatch
-    ? {
-        fileStatus: fileStatus.rejected,
-        hasError: true,
-        errorMessage: fileErrors.wrongType.message.replace(
-          '$MIMETYPES',
-          createMessage()
-        ),
-        errorCode: fileErrors.wrongType.code,
-        errorParams: {
-          mimeTypes
-        }
-      }
-    : {}
+  const fileExtensions = Array.from(
+    new Set(
+      mimeTypes
+        .map((mimeType) => mime.extension(mimeType))
+        .filter(Boolean)
+        .map((extension) => extension.toUpperCase())
+    )
+  )
+
+  const createMessage = () => {
+    const extensions = [...fileExtensions]
+    const last = extensions.pop()
+
+    return extensions.length ? `${extensions.join(', ')} or ${last}` : last
+  }
+
+  return {
+    fileStatus: fileStatus.rejected,
+    hasError: true,
+    errorMessage: fileErrors.wrongType.message.replace(
+      '$MIMETYPES',
+      createMessage()
+    ),
+    errorCode: fileErrors.wrongType.code,
+    errorParams: {
+      mimeTypes,
+      fileExtensions
+    }
+  }
 }
 
 export { handleFile }

--- a/src/server/upload-and-scan/helpers/handle-file.test.js
+++ b/src/server/upload-and-scan/helpers/handle-file.test.js
@@ -98,7 +98,8 @@ describe('#handleFile', () => {
         errorMessage: 'The selected file must be smaller than 1 MB',
         errorCode: fileErrors.tooBig.code,
         errorParams: {
-          maxFileSize: 1000 * 1000
+          maxFileSize: 1000 * 1000,
+          maxFileSizeFormatted: '1 MB'
         },
         fileStatus: 'rejected'
       })
@@ -125,7 +126,8 @@ describe('#handleFile', () => {
         errorMessage: 'The selected file must be smaller than 256 kB',
         errorCode: fileErrors.tooBig.code,
         errorParams: {
-          maxFileSize: 256 * 1000
+          maxFileSize: 256 * 1000,
+          maxFileSizeFormatted: '256 kB'
         },
         fileStatus: 'rejected'
       })
@@ -177,6 +179,18 @@ describe('#handleFile', () => {
             'text/plain',
             'application/pdf',
             'image/png'
+          ],
+          fileExtensions: [
+            'DOC',
+            'DOCX',
+            'CSV',
+            'ODT',
+            'XLSX',
+            'XLS',
+            'RTF',
+            'TXT',
+            'PDF',
+            'PNG'
           ]
         },
         fileStatus: 'rejected'


### PR DESCRIPTION
- Add fileExtensions to FILE_INVALID_TYPE errorParams so tenants can localise without parsing MIME types
- Add maxFileSizeFormatted to FILE_TOO_LARGE errorParams to match the human-readable size in errorMessage
- Keep existing mimeTypes and maxFileSize for backwards compatibility